### PR TITLE
fix(9router): install python3 + g++ for node-gyp during build

### DIFF
--- a/9router/Dockerfile_AntiAntiOps
+++ b/9router/Dockerfile_AntiAntiOps
@@ -3,20 +3,31 @@ FROM node:22-alpine
 ARG ROUTER_VERSION=latest
 ARG OPENCLAW_NPM_PACKAGE=
 
-RUN if [ -n "$OPENCLAW_NPM_PACKAGE" ]; then \
-      npm install -g "$OPENCLAW_NPM_PACKAGE" && \
-      if ! command -v openclaw >/dev/null 2>&1; then \
-        PKG_NAME="${OPENCLAW_NPM_PACKAGE%@*}" && \
-        if [ -n "$PKG_NAME" ]; then \
-          OPENCLAW_BIN="$(node -e "const pkg=require(require('path').join(require('child_process').execSync('npm root -g').toString().trim(), process.argv[1], 'package.json')); const bin=pkg.bin; if (typeof bin === 'string') process.stdout.write(bin); else if (bin && typeof bin === 'object') process.stdout.write(Object.values(bin)[0] || '');" "$PKG_NAME")" && \
-          if [ -n "$OPENCLAW_BIN" ] && [ -x "/usr/local/bin/$OPENCLAW_BIN" ]; then \
-            ln -sf "/usr/local/bin/$OPENCLAW_BIN" /usr/local/bin/openclaw; \
-          fi; \
-        fi; \
-      fi; \
-    fi
-
-RUN npm install -g 9router@$ROUTER_VERSION 
+# Install build toolchain only for the npm install steps. Some openclaw
+# transitive dependencies (e.g. `tree-sitter-bash`) ship a `binding.gyp`
+# and force a native node-gyp rebuild; node-gyp needs python3 + a C/C++
+# compiler. We add them as a virtual package so the apk del at the end
+# of this stage removes the toolchain and keeps the runtime image small.
+RUN apk add --no-cache --virtual .gyp-build-deps \
+      python3 \
+      make \
+      g++ \
+      libc-dev \
+    && if [ -n "$OPENCLAW_NPM_PACKAGE" ]; then \
+         npm install -g "$OPENCLAW_NPM_PACKAGE" && \
+         if ! command -v openclaw >/dev/null 2>&1; then \
+           PKG_NAME="${OPENCLAW_NPM_PACKAGE%@*}" && \
+           if [ -n "$PKG_NAME" ]; then \
+             OPENCLAW_BIN="$(node -e "const pkg=require(require('path').join(require('child_process').execSync('npm root -g').toString().trim(), process.argv[1], 'package.json')); const bin=pkg.bin; if (typeof bin === 'string') process.stdout.write(bin); else if (bin && typeof bin === 'object') process.stdout.write(Object.values(bin)[0] || '');" "$PKG_NAME")" && \
+             if [ -n "$OPENCLAW_BIN" ] && [ -x "/usr/local/bin/$OPENCLAW_BIN" ]; then \
+               ln -sf "/usr/local/bin/$OPENCLAW_BIN" /usr/local/bin/openclaw; \
+             fi; \
+           fi; \
+         fi; \
+       fi \
+    && npm install -g 9router@$ROUTER_VERSION \
+    && npm cache clean --force \
+    && apk del .gyp-build-deps
 
 EXPOSE 20128
 


### PR DESCRIPTION
## Symptom

The `Build and Push 9router Image` workflow started failing on `linux/arm64` (run [25372451169](https://github.com/antiantiops/toolkit/actions/runs/25372451169)). Build step `Build and push image` exits non-zero with:

```
npm error gyp ERR! find Python ... Could not find any Python installation to use
npm error gyp ERR! cwd /usr/local/lib/node_modules/openclaw/node_modules/tree-sitter-bash
```

## Root cause

`openclaw` (latest) now transitively depends on `tree-sitter-bash`, which ships a `binding.gyp` and triggers a native `node-gyp` rebuild during `npm install -g openclaw@latest`.

The `node:22-alpine` base image does not ship `python3` or a C/C++ compiler, so node-gyp can't even reach `configure` (especially on linux/arm64, which the GH runner emulates via QEMU) before npm aborts the install.

## Fix

Add a virtual apk package `.gyp-build-deps` with `python3` + `make` + `g++` + `libc-dev` for the npm install steps, then `apk del` removes the toolchain so the final runtime layer stays slim.

The two previous `RUN` blocks are now folded into a single `RUN` so apk install + apk del happen in the same layer (no toolchain bloat in the published image).

## Verification plan
- After merge, master push triggers `build-9router.yml`.
- Expect: `Build and push image` step now succeeds on both `linux/amd64` and `linux/arm64`.
- Image tag pushed should still be `antiantiops/9router:0.4.18`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image builds for improved efficiency and reduced image size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->