### PR TITLE
debug: split 9router Docker npm install steps

### DIFF
--- a/9router/Dockerfile_AntiAntiOps
+++ b/9router/Dockerfile_AntiAntiOps
@@ -6,27 +6,36 @@ ARG OPENCLAW_NPM_PACKAGE=
 # Install build toolchain only for the npm install steps. Some openclaw
 # transitive dependencies (e.g. `tree-sitter-bash`) ship a `binding.gyp`
 # and force a native node-gyp rebuild; node-gyp needs python3 + a C/C++
-# compiler. We add them as a virtual package so the apk del at the end
-# of this stage removes the toolchain and keeps the runtime image small.
+# compiler. Keep OpenClaw and 9router installs in separate RUN layers so
+# multi-arch CI logs show which package fails under QEMU/arm64.
 RUN apk add --no-cache --virtual .gyp-build-deps \
       python3 \
       make \
       g++ \
-      libc-dev \
-    && if [ -n "$OPENCLAW_NPM_PACKAGE" ]; then \
-         npm install -g "$OPENCLAW_NPM_PACKAGE" && \
-         if ! command -v openclaw >/dev/null 2>&1; then \
-           PKG_NAME="${OPENCLAW_NPM_PACKAGE%@*}" && \
-           if [ -n "$PKG_NAME" ]; then \
-             OPENCLAW_BIN="$(node -e "const pkg=require(require('path').join(require('child_process').execSync('npm root -g').toString().trim(), process.argv[1], 'package.json')); const bin=pkg.bin; if (typeof bin === 'string') process.stdout.write(bin); else if (bin && typeof bin === 'object') process.stdout.write(Object.values(bin)[0] || '');" "$PKG_NAME")" && \
-             if [ -n "$OPENCLAW_BIN" ] && [ -x "/usr/local/bin/$OPENCLAW_BIN" ]; then \
-               ln -sf "/usr/local/bin/$OPENCLAW_BIN" /usr/local/bin/openclaw; \
-             fi; \
-           fi; \
-         fi; \
-       fi \
+      libc-dev
+
+RUN if [ -n "$OPENCLAW_NPM_PACKAGE" ]; then \
+      echo "Installing OpenClaw package: $OPENCLAW_NPM_PACKAGE"; \
+      npm install -g "$OPENCLAW_NPM_PACKAGE"; \
+      if ! command -v openclaw >/dev/null 2>&1; then \
+        PKG_NAME="${OPENCLAW_NPM_PACKAGE%@*}"; \
+        if [ -n "$PKG_NAME" ]; then \
+          OPENCLAW_BIN="$(node -e "const pkg=require(require('path').join(require('child_process').execSync('npm root -g').toString().trim(), process.argv[1], 'package.json')); const bin=pkg.bin; if (typeof bin === 'string') process.stdout.write(bin); else if (bin && typeof bin === 'object') process.stdout.write(Object.values(bin)[0] || '');" "$PKG_NAME")"; \
+          if [ -n "$OPENCLAW_BIN" ] && [ -x "/usr/local/bin/$OPENCLAW_BIN" ]; then \
+            ln -sf "/usr/local/bin/$OPENCLAW_BIN" /usr/local/bin/openclaw; \
+          fi; \
+        fi; \
+      fi; \
+      command -v openclaw || true; \
+    else \
+      echo "Skipping OpenClaw install because OPENCLAW_NPM_PACKAGE is empty"; \
+    fi
+
+RUN echo "Installing 9router package: 9router@$ROUTER_VERSION" \
     && npm install -g 9router@$ROUTER_VERSION \
-    && npm cache clean --force \
+    && command -v 9router
+
+RUN npm cache clean --force \
     && apk del .gyp-build-deps
 
 EXPOSE 20128


### PR DESCRIPTION
Split OpenClaw and 9router npm installs into separate Dockerfile RUN layers so the multi-arch GitHub Actions log identifies whether the arm64/QEMU SIGILL happens during OpenClaw install or 9router install.

Context: run 26221868955 / job 77158642339 failed on linux/arm64 with qemu illegal instruction exit 132 while amd64 completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build process and dependency installation to improve build efficiency and layer caching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/antiantiops/toolkit/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->