### PR TITLE
feat: confirm Strix scan authorization

### DIFF
--- a/.github/workflows/strix-manual-scan.yml
+++ b/.github/workflows/strix-manual-scan.yml
@@ -4,9 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: "Authorized HTTPS target, e.g. https://nimtechnology.com"
+        description: "HTTPS target to scan, e.g. https://example.com"
         required: true
         type: string
+      authorized_target:
+        description: "I own this target or have written authorization to scan it"
+        required: true
+        type: boolean
+        default: false
       scan_mode:
         description: "Strix scan mode"
         required: true
@@ -28,6 +33,7 @@ jobs:
         id: target
         env:
           TARGET: ${{ inputs.target }}
+          AUTHORIZED_TARGET: ${{ inputs.authorized_target }}
         run: |
           python3 - <<'PY'
           import os
@@ -36,20 +42,17 @@ jobs:
 
           target = os.environ["TARGET"]
           parsed = urlsplit(target)
-          hostname = (parsed.hostname or "").rstrip(".").lower()
-          valid_hostname = (
-              hostname == "nimtechnology.com"
-              or hostname.endswith(".nimtechnology.com")
-          )
+          hostname = (parsed.hostname or "").rstrip(".")
 
           if (
-              parsed.scheme != "https"
-              or not valid_hostname
+              os.environ.get("AUTHORIZED_TARGET") != "true"
+              or parsed.scheme != "https"
+              or not hostname
               or parsed.username is not None
               or parsed.password is not None
               or any(character in target for character in "\r\n\0")
           ):
-              print(f"::error::Target is not allowlisted: {target}", file=sys.stderr)
+              print("::error::Target must be HTTPS and authorization confirmation must be true", file=sys.stderr)
               raise SystemExit(1)
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:


### PR DESCRIPTION
Removes fixed domain allowlist. Each manual scan requires explicit `authorized_target: true`, while retaining HTTPS, hostname, no-credentials, and control-character validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual scans can now be configured for any HTTPS target, rather than a predefined domain.
  * Added an explicit authorization confirmation before a scan can run.

* **Bug Fixes**
  * Improved target validation to require HTTPS, a valid hostname, no embedded credentials, and no control characters.
  * Prevented scans from proceeding without confirmed authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->