### PR TITLE
ci: publish tarot image to ghcr

### DIFF
--- a/.github/workflows/build-tarot.yml
+++ b/.github/workflows/build-tarot.yml
@@ -1,0 +1,63 @@
+name: Build and Publish Tarot Image
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/build-tarot.yml'
+      - 'tarot/**'
+  pull_request:
+    branches: [master]
+    paths:
+      - '.github/workflows/build-tarot.yml'
+      - 'tarot/**'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/antiantiops/tarot
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./tarot
+          file: ./tarot/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=tarot
+          cache-to: type=gha,mode=max,scope=tarot


### PR DESCRIPTION
## Summary
- add Tarot Docker image GitHub Actions workflow
- publish multi-arch image to `ghcr.io/antiantiops/tarot`
- build pull requests without publishing

## Validation
- workflow static assertions passed
- `git diff --check` passed
- local Docker build unavailable because Docker CLI is not installed on this host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated builds for Tarot container images on amd64 and arm64 platforms.
  * Publishes images to the container registry with `latest` and commit-specific tags.
  * Supports builds triggered by code changes, pull requests, and manual runs.
  * Uses build caching to improve workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->